### PR TITLE
[WIP] cache_resolve can include additonal params from the resolution

### DIFF
--- a/lib/absinthe_cache.ex
+++ b/lib/absinthe_cache.ex
@@ -130,18 +130,22 @@ defmodule AbsintheCache do
 
   defp resolver(resolver_fn, name, opts) do
     root_key = Keyword.get(opts, :root_key, :id)
+    additonal_args_fun = Keyword.get(opts, :resolution_fun, fn _ -> nil end)
+
     # Works only for top-level resolvers and fields with root object that has `id` field
     fn
       %{^root_key => key} = root, args, resolution ->
         fun = fn -> resolver_fn.(root, args, resolution) end
+        additional_args = additonal_args_fun.(resolution)
 
-        cache_key({name, key, resolution.source}, args, opts)
+        cache_key({name, key, resolution.source, additional_args}, args, opts)
         |> get_or_store(fun)
 
       %{}, args, resolution ->
         fun = fn -> resolver_fn.(%{}, args, resolution) end
+        additional_args = additonal_args_fun.(resolution)
 
-        cache_key({name, resolution.source}, args, opts)
+        cache_key({name, resolution.source, additional_args}, args, opts)
         |> get_or_store(fun)
     end
   end

--- a/lib/absinthe_cache.ex
+++ b/lib/absinthe_cache.ex
@@ -14,9 +14,9 @@ defmodule AbsintheCache do
 
   @compile :inline_list_funcs
   @compile {:inline,
+            __from__: 2,
             wrap: 2,
             wrap: 3,
-            from: 2,
             resolver: 3,
             store: 2,
             store: 3,
@@ -31,15 +31,15 @@ defmodule AbsintheCache do
   alias AbsintheCache.ConCacheProvider, as: CacheProvider
 
   @doc ~s"""
-  Macro that's used instead of Absinthe's `resolve`. This resolver can perform
-  the following operations:
-  1. Get the stored value if there is one. The resolver function is not
-  evaluated at all in this case.
-  2. Evaluate the resolver function and store the value in the cache if it is
-  not present there.
-  3. Handle the `Absinthe.Middlewar.Async` and `Absinthe.Middleware.Dataloader`
-  middlewares. In order to handle them, the function that executes the actual
-  evaluation is wrapped in a function that handles the cache interactions
+  A drop-in replace of the `resolve` macro provided by `use Absinthe.Schema.Notation`
+  that stores the result and subsequent calls fetch the value from the cache.
+
+  This resolver can perform the following operations:
+  - Get the stored value if there is one. The resolver function is not evaluated
+  at all in this case.
+  - Evaluate the resolver function and store the value in the cache.
+  - Handle the `Absinthe.Middlewar.Async` and `Absinthe.Middleware.Dataloader`
+  middlewares.
 
   There are two options for the passed function:
   1. It can be a captured named function because its name is extracted
@@ -47,56 +47,73 @@ defmodule AbsintheCache do
   2. If the function is anonymous or a different name should be used, a second
   parameter with that name must be passed.
 
-  Just like `resolve` comming from Absinthe, `cache_resolve` supports the `{:ok, value}`
-  and `{:error, reason}` result tuples. The `:ok` tuples are cached while the `:error`
-  tuples are not.
+  Just like `resolve`, `cache_resolve` supports the `{:ok, value}` and `{:error, reason}`
+  result tuples. The `:ok` tuples are cached while the `:error` tuples are not.
 
-  But `cache_resolve` knows how to handle a third type of response format. When
-  `{:nocache, {:ok, value}}` is returned as the result the cache does **not** cache
-  the value and just returns `{:ok, value}`. This is particularly useful when
-  the result can't be constructed but returning an error will crash the whole query.
+  `cache_resolve` handles a third type of response format.
+  When `{:nocache, {:ok, value}}` is returned as the result the cache does **not**
+  cache the value and just returns `{:ok, value}`. This is useful when the result
+  can't be constructed but returning an error will crash the whole query.
   In such cases a default/filling value can be passed (0, nil, "No data", etc.)
-  and the next query will try to resolve it again
+  and the next query will try to resolve it again.
+
+  Options:
+  - :ttl - Override the base default TTL (time-to-live) of 300 seconds, used
+  to compute the cache duration. The total duration is the TTL plus some random value
+  - :max_ttl_offset - Override the default maximum TTL offset of 120 seconds.
+  A random integer value between 0 and max_ttl_offset is added to the base TTL
+  to derive the full duration of the cache.
+  - :additonal_args_fun - 1-arity function accepting the %Absinthe.Resolution{}
+  struct used to provide additonal arguments that will be passed to the function
+  computing the cache key
+  - :fun_name - Provide a name in case of anonymous function passed to the resolver
+  or to change the name of the provided captured named function.
   """
 
   defmacro cache_resolve(captured_mfa_ast, opts \\ []) do
     quote do
       middleware(
         Absinthe.Resolution,
-        CacheMod.from(unquote(captured_mfa_ast), unquote(opts))
+        CacheMod.__from__(unquote(captured_mfa_ast), unquote(opts))
       )
     end
   end
 
   @doc ~s"""
-  Exposed as sometimes it can be useful to use it outside the macros.
+  Given a 0-arity function, return another 0-arity function that wraps the
+  original in such a way that:
+  - On execution checks if the value is present in the cache and returns it.
+  - If it's not in the cache it gets executed and the value is stored in the cache.
 
-  Gets a function, name and arguments and returns a new function that:
-  1. On execution checks if the value is present in the cache and returns it
-  2. If it's not in the cache it gets executed and the value is stored in the cache.
+  Arguments:
+  - cache_fun - The 0-arity function to be cached
+  - name - Name for the function to be used only for deriving the key
+  - args - Args for the function to be used only for deriving the cache key
+  - opts - Options passed to the cache key. :ttl and :max_ttl_offset are also
+  supported with the same meaning as in `cache_resolve/3`
 
-  NOTE: `cached_func` is a function with arity 0. That means if you want to use it
+  NOTE: `cache_fun` is a function with arity 0. That means if you want to use it
   in your code and you want some arguments you should use it like this:
-    > Cache.wrap(
-    >   fn ->
-    >     fetch_last_price_record(pair)
-    >   end,
-    >   :fetch_price_last_record, %{pair: pair}
-    > ).()
+     Cache.wrap(
+       fn -> fetch_last_price_record(pair) end,
+       :fetch_price_last_record, %{pair: pair}
+     ).()
   """
-  def wrap(cached_func, name, args \\ %{}, opts \\ []) do
+  @spec wrap((() -> t), name, args, Keyword.t()) :: (() -> t)
+        when t: any(), name: any(), args: any()
+  def wrap(cache_fun, name, args \\ %{}, opts \\ []) do
     fn ->
       CacheProvider.get_or_store(
         @cache_name,
         cache_key(name, args, opts),
-        cached_func,
+        cache_fun,
         &cache_modify_middleware/3
       )
     end
   end
 
   @doc ~s"""
-  Clears the whole cache. Slow.
+  Clears the whole cache.
   """
   def clear_all() do
     CacheProvider.clear_all(@cache_name)
@@ -113,8 +130,29 @@ defmodule AbsintheCache do
     CacheProvider.get(@cache_name, key)
   end
 
+  def store(cache_name \\ @cache_name, cache_key, value) do
+    CacheProvider.store(cache_name, cache_key, value)
+  end
+
+  def cache_key(name, args, opts \\ []) do
+    base_ttl = Keyword.get(opts, :ttl, @ttl)
+    max_ttl_offset = Keyword.get(opts, :max_ttl_offset, @max_ttl_offset)
+
+    # The TTL is the base TTL + a random value in the interval [0; max_ttl_offset]
+    # This is helpful in scenarios where a list of returned objects has cached fields
+    # In order to avoid all caches expiring at the same time, adding a random
+    # offset will rougly make it so on average max_ttl_offset / ttl_check_interval
+    # percent of the fields will expire
+    ttl = base_ttl + ({name, args} |> :erlang.phash2(max_ttl_offset))
+
+    args = args |> convert_values(ttl)
+    cache_key = {name, args} |> :erlang.phash2()
+
+    {cache_key, ttl}
+  end
+
   @doc false
-  def from(captured_mfa, opts) when is_function(captured_mfa) do
+  def __from__(captured_mfa, opts) when is_function(captured_mfa) do
     # Public so it can be used by the resolve macros. You should not use it.
     case Keyword.pop(opts, :fun_name) do
       {nil, opts} ->
@@ -130,31 +168,27 @@ defmodule AbsintheCache do
 
   defp resolver(resolver_fn, name, opts) do
     root_key = Keyword.get(opts, :root_key, :id)
-    additonal_args_fun = Keyword.get(opts, :resolution_fun, fn _ -> nil end)
+    additional_args_fun = Keyword.get(opts, :additional_args_fun, fn _ -> nil end)
 
     # Works only for top-level resolvers and fields with root object that has `id` field
     fn
       %{^root_key => key} = root, args, resolution ->
         fun = fn -> resolver_fn.(root, args, resolution) end
-        additional_args = additonal_args_fun.(resolution)
+        additional_args = additional_args_fun.(resolution)
 
         cache_key({name, key, resolution.source, additional_args}, args, opts)
         |> get_or_store(fun)
 
       %{}, args, resolution ->
         fun = fn -> resolver_fn.(%{}, args, resolution) end
-        additional_args = additonal_args_fun.(resolution)
+        additional_args = additional_args_fun.(resolution)
 
         cache_key({name, resolution.source, additional_args}, args, opts)
         |> get_or_store(fun)
     end
   end
 
-  def store(cache_name \\ @cache_name, cache_key, value) do
-    CacheProvider.store(cache_name, cache_key, value)
-  end
-
-  def get_or_store(cache_name \\ @cache_name, cache_key, resolver_fn) do
+  defp get_or_store(cache_name \\ @cache_name, cache_key, resolver_fn) do
     CacheProvider.get_or_store(
       cache_name,
       cache_key,
@@ -202,42 +236,16 @@ defmodule AbsintheCache do
     {:middleware, midl, {loader, caching_callback}}
   end
 
-  # Helper functions
-
-  def cache_key(name, args, opts \\ []) do
-    base_ttl = Keyword.get(opts, :ttl, @ttl)
-    max_ttl_offset = Keyword.get(opts, :max_ttl_offset, @max_ttl_offset)
-    slug = Map.get(args, :slug, "")
-
-    ttl = base_ttl + ({name, slug} |> :erlang.phash2(max_ttl_offset))
-
-    args =
-      args
-      |> convert_values(ttl)
-
-    cache_key =
-      [name, args]
-      |> :erlang.phash2()
-
-    {cache_key, ttl}
-  end
-
   # Convert the values for using in the cache. A special treatement is done for
   # `%DateTime{}` so all datetimes in a @ttl sized window are treated the same
-  defp convert_values(%DateTime{} = v, ttl) do
-    div(DateTime.to_unix(v, :second), ttl)
-  end
-
+  defp convert_values(%DateTime{} = v, ttl), do: div(DateTime.to_unix(v, :second), ttl)
   defp convert_values(%_{} = v, _), do: Map.from_struct(v)
 
   defp convert_values(args, ttl) when is_list(args) or is_map(args) do
     args
     |> Enum.map(fn
-      {k, v} ->
-        [k, convert_values(v, ttl)]
-
-      data ->
-        convert_values(data, ttl)
+      {k, v} -> [k, convert_values(v, ttl)]
+      data -> convert_values(data, ttl)
     end)
   end
 

--- a/lib/document_provider.ex
+++ b/lib/document_provider.ex
@@ -79,7 +79,7 @@ defmodule AbsintheCache.DocumentProvider do
         # Access opts from the surrounding `AbsintheCache.DocumentProvider` module
         @ttl Keyword.get(opts, :ttl, 120)
         @max_ttl_ffset Keyword.get(opts, :max_ttl_offset, 60)
-        @cache_key_fun Keyword.get(opts, :additional_cache_key_args_fun, fn _ -> :ok end)
+        @cache_key_fun Keyword.get(opts, :additional_args_fun, fn _ -> nil end)
 
         @spec run(Absinthe.Blueprint.t(), Keyword.t()) :: Absinthe.Phase.result_t()
         def run(bp_root, _) do


### PR DESCRIPTION
If additional params from the resolution are needed to include in the cache key:
```elixir
cache_resolve(&Resolver.my_fun/3, additional_args_fun: fn resolution -> resolution.context.some_field end)
``` 