### PR TITLE
Add Cachex cache provider

### DIFF
--- a/lib/cache_provider.ex
+++ b/lib/cache_provider.ex
@@ -1,7 +1,6 @@
-defmodule AbsintheCache.Behaviour do
+defmodule AbsintheCache.CacheProvider do
   @moduledoc """
   Behaviour that the cache needs to conform to.
-  # TODO: Write more docs
   """
 
   @type hash :: String.t()
@@ -11,29 +10,41 @@ defmodule AbsintheCache.Behaviour do
   @type cache :: atom()
   @type size_type :: :megabytes
 
+  @callback start_link(Keyword.t()) :: {:ok, pid}
+
+  @callback child_spec(Keyword.t()) :: Supervisor.child_spec()
+
   @doc ~s"""
-  Get the value for the given key from the cache.
+  Get the value for the given key from the cache
   """
   @callback get(cache, hash) :: {:ok, any} | {:error, error} | nil
 
   @doc ~s"""
-  Put a query document in the cache with the key as cache key.
+  Put a query document in the cache with the key as cache key
   """
   @callback store(cache, key, stored_value) :: :ok | {:error, error}
 
   @doc ~s"""
   Get the value for the given key from the cache. If there is no record with this
   key, execute `fun`, store its value under the `key` key if and only if it is not
-  an error and return in. If there is more than one query for that key, `fun`
-  should be executed only once and the rest of the queries will wait until the result.
+  an error and return in. If there are more than one queries for that key, `fun`
+  must be executed only once and the rest of the queries will wait until the result
   is ready.
   """
   @callback get_or_store(cache, key, fun, fun) :: {:ok, stored_value} | {:error, error}
-  @callback get_or_store(cache, key, fun) :: {:ok, stored_value} | {:error, error}
 
-  @callback size(cache, size_type) :: float()
+  @doc ~s"""
+  Get the size of the cache in megabytes
+  """
+  @callback size(cache) :: float()
 
+  @doc ~s"""
+  Count the elements in the cache
+  """
+  @callback count(cache) :: non_neg_integer()
+
+  @doc ~s"""
+  Delete all objects in the cache. The cache itself is not deleted
+  """
   @callback clear_all(cache) :: :ok
-
-  @optional_callbacks get_or_store: 3, get_or_store: 4
 end

--- a/lib/cache_provider.ex
+++ b/lib/cache_provider.ex
@@ -1,4 +1,4 @@
-defmodule AbsintheCache.CacheProvider do
+defmodule AbsintheCache.Behaviour do
   @moduledoc """
   Behaviour that the cache needs to conform to.
   """

--- a/lib/cachex_cache_provider/cachex_cache_provider.ex
+++ b/lib/cachex_cache_provider/cachex_cache_provider.ex
@@ -1,0 +1,195 @@
+if Code.ensure_loaded?(Cachex) do
+  defmodule AbsintheCache.CachexProvider do
+    @behaviour AbsintheCache.CacheProvider
+    @default_ttl_seconds 300
+
+    @max_lock_acquired_time_ms 60_000
+
+    import Cachex.Spec
+
+    @compile inline: [
+               execute_cache_miss_function: 4,
+               handle_execute_cache_miss_function: 4,
+               obtain_lock: 3
+             ]
+
+    @impl AbsintheCache.CacheProvider
+    def start_link(opts) do
+      Cachex.start_link(opts(opts))
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def child_spec(opts) do
+      Supervisor.child_spec({Cachex, opts(opts)}, id: Keyword.fetch!(opts, :id))
+    end
+
+    defp opts(opts) do
+      [
+        name: Keyword.fetch!(opts, :name),
+        # When the keys reach 2 million, remove 30% of the
+        # least recently written keys
+        limit: 2_000_000,
+        policy: Cachex.Policy.LRW,
+        reclaim: 0.3,
+        # How often the Janitor process runs to clean the cache
+        interval: 5000,
+        # The default TTL of keys in the cache
+        expiration:
+          expiration(
+            default: :timer.seconds(@default_ttl_seconds),
+            interval: :timer.seconds(10),
+            lazy: true
+          )
+      ]
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def size(cache) do
+      {:ok, bytes_size} = Cachex.inspect(cache, {:memory, :bytes})
+      (bytes_size / (1024 * 1024)) |> Float.round(2)
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def count(cache) do
+      {:ok, count} = Cachex.size(cache)
+      count
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def clear_all(cache) do
+      {:ok, _} = Cachex.clear(cache)
+      :ok
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def get(cache, key) do
+      case Cachex.get(cache, true_key(key)) do
+        {:ok, {:stored, value}} -> value
+        _ -> nil
+      end
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def store(cache, key, value) do
+      case value do
+        {:error, _} ->
+          :ok
+
+        {:nocache, _} ->
+          Process.put(:has_nocache_field, true)
+
+          :ok
+
+        _ ->
+          cache_item(cache, key, {:stored, value})
+      end
+    end
+
+    @impl AbsintheCache.CacheProvider
+    def get_or_store(cache, key, func, cache_modify_middleware) do
+      true_key = true_key(key)
+
+      case Cachex.get(cache, true_key) do
+        {:ok, {:stored, value}} ->
+          value
+
+        _ ->
+          execute_cache_miss_function(cache, key, func, cache_modify_middleware)
+      end
+    end
+
+    defp execute_cache_miss_function(cache, key, func, cache_modify_middleware) do
+      # This is the only place where we need to have the transactional get_or_store
+      # mechanism. Cachex.fetch! is running in multiple processes, which causes issues
+      # when testing. Cachex.transaction has a non-configurable timeout. We actually
+      # can achieve the required behavior by manually getting and realeasing the lock.
+      # The transactional guarantees are not needed.
+      cache_record = Cachex.Services.Overseer.ensure(cache)
+
+      # Start a process that will handle the unlock in case this process terminates
+      # without releasing the lock. The process is not linked to the current one so
+      # it can continue to live and do its job even if this process terminates.
+      {:ok, unlocker_pid} =
+        __MODULE__.Unlocker.start(max_lock_acquired_time_ms: @max_lock_acquired_time_ms)
+
+      unlock_fun = fn -> Cachex.Services.Locksmith.unlock(cache_record, [true_key(key)]) end
+
+      try do
+        true = obtain_lock(cache_record, [true_key(key)])
+        _ = GenServer.cast(unlocker_pid, {:unlock_after, unlock_fun})
+
+        case Cachex.get(cache, true_key(key)) do
+          {:ok, {:stored, value}} ->
+            # First check if the result has not been stored while waiting for the lock.
+            value
+
+          _ ->
+            handle_execute_cache_miss_function(
+              cache,
+              key,
+              _result = func.(),
+              cache_modify_middleware
+            )
+        end
+      after
+        true = unlock_fun.()
+        # We expect the process to unlock only in case we don't reach here for some reason.
+        # If we're here we can kill the process. If the process has already unlocked
+        _ = GenServer.cast(unlocker_pid, :stop)
+      end
+    end
+
+    defp obtain_lock(cache_record, keys, attempt \\ 0)
+
+    defp obtain_lock(_cache_record, _keys, 30) do
+      raise("Obtaining cache lock failed because of timeout")
+    end
+
+    defp obtain_lock(cache_record, keys, attempt) do
+      case Cachex.Services.Locksmith.lock(cache_record, keys) do
+        false ->
+          # In case the lock cannot be obtained, try again after some time
+          # In the beginning the next attempt is scheduled in an exponential
+          # backoff fashion - 10, 130, 375, 709, etc. milliseconds
+          # The backoff is capped at 2 seconds
+          sleep_ms = (:math.pow(attempt * 20, 1.6) + 10) |> trunc()
+          sleep_ms = Enum.min([sleep_ms, 2000])
+
+          Process.sleep(sleep_ms)
+          obtain_lock(cache_record, keys, attempt + 1)
+
+        true ->
+          true
+      end
+    end
+
+    defp handle_execute_cache_miss_function(cache, key, result, cache_modify_middleware) do
+      case result do
+        {:middleware, _, _} = tuple ->
+          cache_modify_middleware.(cache, key, tuple)
+
+        {:nocache, value} ->
+          Process.put(:has_nocache_field, true)
+          value
+
+        {:error, _} = error ->
+          error
+
+        {:ok, _value} = ok_tuple ->
+          cache_item(cache, key, {:stored, ok_tuple})
+          ok_tuple
+      end
+    end
+
+    defp cache_item(cache, {key, ttl}, value) when is_integer(ttl) do
+      Cachex.put(cache, key, value, ttl: :timer.seconds(ttl))
+    end
+
+    defp cache_item(cache, key, value) do
+      Cachex.put(cache, key, value, ttl: :timer.seconds(@default_ttl_seconds))
+    end
+
+    defp true_key({key, ttl}) when is_integer(ttl), do: key
+    defp true_key(key), do: key
+  end
+end

--- a/lib/cachex_cache_provider/cachex_cache_provider.ex
+++ b/lib/cachex_cache_provider/cachex_cache_provider.ex
@@ -1,6 +1,6 @@
 if Code.ensure_loaded?(Cachex) do
   defmodule AbsintheCache.CachexProvider do
-    @behaviour AbsintheCache.CacheProvider
+    @behaviour AbsintheCache.Behaviour
     @default_ttl_seconds 300
 
     @max_lock_acquired_time_ms 60_000
@@ -13,12 +13,12 @@ if Code.ensure_loaded?(Cachex) do
                obtain_lock: 3
              ]
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def start_link(opts) do
       Cachex.start_link(opts(opts))
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def child_spec(opts) do
       Supervisor.child_spec({Cachex, opts(opts)}, id: Keyword.fetch!(opts, :id))
     end
@@ -43,25 +43,25 @@ if Code.ensure_loaded?(Cachex) do
       ]
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def size(cache) do
       {:ok, bytes_size} = Cachex.inspect(cache, {:memory, :bytes})
       (bytes_size / (1024 * 1024)) |> Float.round(2)
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def count(cache) do
       {:ok, count} = Cachex.size(cache)
       count
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def clear_all(cache) do
       {:ok, _} = Cachex.clear(cache)
       :ok
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def get(cache, key) do
       case Cachex.get(cache, true_key(key)) do
         {:ok, {:stored, value}} -> value
@@ -69,7 +69,7 @@ if Code.ensure_loaded?(Cachex) do
       end
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def store(cache, key, value) do
       case value do
         {:error, _} ->
@@ -85,7 +85,7 @@ if Code.ensure_loaded?(Cachex) do
       end
     end
 
-    @impl AbsintheCache.CacheProvider
+    @impl AbsintheCache.Behaviour
     def get_or_store(cache, key, func, cache_modify_middleware) do
       true_key = true_key(key)
 

--- a/lib/cachex_cache_provider/cachex_unlocker.ex
+++ b/lib/cachex_cache_provider/cachex_unlocker.ex
@@ -1,0 +1,48 @@
+defmodule AbsintheCache.CachexProvider.Unlocker do
+  @moduledoc ~s"""
+  Module that makes sure that locks acquired during get_or_store locking in
+  the Cachex provider.
+
+  When locks are acquired, a process is spawned that unlocks the lock in case
+  something wrong does with the process that obtained it. If the process finishes
+  fast without issues it will kill this process.
+  """
+
+  use GenServer
+
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
+  def init(opts) do
+    max_lock_acquired_time_ms = Keyword.fetch!(opts, :max_lock_acquired_time_ms)
+    # If the process that started the Unlocker terminates before sending the unlock_after
+    # message this process will live forever. Because of this schedule a termination after
+    # at least 2 `max_lock_acquired_time_ms` epochs has passed. Two are needed so it waits
+    # both the lock obtaining time (up to ~55-60 seconds) and the actual lock holding time
+    Process.send_after(self(), :self_terminate, 2 * max_lock_acquired_time_ms + 1000)
+    {:ok, %{max_lock_acquired_time_ms: max_lock_acquired_time_ms}}
+  end
+
+  def handle_cast({:unlock_after, unlock_fun}, state) do
+    Process.send_after(self(), {:unlock_lock, unlock_fun}, state[:max_lock_acquired_time_ms])
+    {:noreply, state}
+  end
+
+  def handle_cast(:stop, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:unlock_lock, unlock_fun}, state) do
+    unlock_fun.()
+    {:noreply, state}
+  end
+
+  def handle_info(:self_terminate, state) do
+    {:stop, :normal, state}
+  end
+
+  def terminate(_reason, _state) do
+    :normal
+  end
+end

--- a/lib/con_cache_provider.ex
+++ b/lib/con_cache_provider.ex
@@ -1,8 +1,8 @@
 defmodule AbsintheCache.ConCacheProvider do
   @moduledoc ~s"""
-  Implements AbsintheCache.CacheProvider for con_cache
+  Implements AbsintheCache.Behaviour for con_cache
   """
-  @behaviour AbsintheCache.CacheProvider
+  @behaviour AbsintheCache.Behaviour
 
   @compile {:inline,
             get: 2,
@@ -14,12 +14,12 @@ defmodule AbsintheCache.ConCacheProvider do
 
   @max_cache_ttl 7200
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def start_link(opts) do
     ConCache.start_link(opts(opts))
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def child_spec(opts) do
     Supervisor.child_spec({ConCache, opts(opts)}, id: Keyword.fetch!(opts, :id))
   end
@@ -33,14 +33,14 @@ defmodule AbsintheCache.ConCacheProvider do
     ]
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def size(cache) do
     bytes_size = :ets.info(ConCache.ets(cache), :memory) * :erlang.system_info(:wordsize)
 
     _megabytes_size = (bytes_size / (1024 * 1024)) |> Float.round(2)
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def count(cache) do
     cache
     |> ConCache.ets()
@@ -48,7 +48,7 @@ defmodule AbsintheCache.ConCacheProvider do
     |> length
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def clear_all(cache) do
     cache
     |> ConCache.ets()
@@ -56,7 +56,7 @@ defmodule AbsintheCache.ConCacheProvider do
     |> Enum.each(fn {key, _} -> ConCache.delete(cache, key) end)
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def get(cache, key) do
     case ConCache.get(cache, true_key(key)) do
       {:stored, value} -> value
@@ -64,7 +64,7 @@ defmodule AbsintheCache.ConCacheProvider do
     end
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def store(cache, key, value) do
     case value do
       {:error, _} ->
@@ -79,7 +79,7 @@ defmodule AbsintheCache.ConCacheProvider do
     end
   end
 
-  @impl AbsintheCache.CacheProvider
+  @impl AbsintheCache.Behaviour
   def get_or_store(cache, key, func, cache_modify_middleware) do
     # Do not include the TTL as part of the key name.
     true_key = true_key(key)


### PR DESCRIPTION
Related PR in the original repo: https://github.com/santiment/sanbase2/pull/3272

`ConCache` seems to have problems when too many calls are made. The primary cause is the single process bottleneck issue. The main issue is encountered with the handling of TTL, and as a result the values that are put in cache have their TTLs not handled properly, which leads to out of memory kills. Check screenshot:
<img width="1891" alt="image" src="https://user-images.githubusercontent.com/6518376/181239736-79113814-e3f2-488b-a1c5-50fa6a2517df.png">

Because of this, we've chosen to try using Cachex. After switching to Cachex a huge improvements in CPU and RAM usage is observed:
<img width="1909" alt="image" src="https://user-images.githubusercontent.com/6518376/181239898-4b3276b4-4624-4c79-920a-4335a3d07774.png">

Cachex is used in a non-standard way, implementing some of the things manually. There were issues encountered when using the provided functions by derfault. 