### PR TITLE
Fix cache macro

### DIFF
--- a/lib/before_send.ex
+++ b/lib/before_send.ex
@@ -38,7 +38,7 @@ defmodule AbsintheCache.BeforeSend do
         # to infinite storing the same value if there are enough requests
 
         queries = queries_in_request(blueprint)
-        do_not_cache? = is_nil(Process.get(:do_not_cache_query))
+        do_not_cache? = Process.get(:do_not_cache_query) != nil
 
         case do_not_cache? or has_graphql_errors?(blueprint) do
           true -> :ok

--- a/lib/document_provider.ex
+++ b/lib/document_provider.ex
@@ -110,8 +110,7 @@ defmodule AbsintheCache.DocumentProvider do
               # This can lead to infinite storing the same value
               Process.put(:do_not_cache_query, true)
 
-              {:jump, %{bp_root | result: result},
-               AbsintheCache.Phase.Document.Execution.Idempotent}
+              {:jump, %{bp_root | result: result}, AbsintheCache.DocumentProvider.Idempotent}
           end
         end
 

--- a/lib/document_provider.ex
+++ b/lib/document_provider.ex
@@ -79,7 +79,13 @@ defmodule AbsintheCache.DocumentProvider do
         # Access opts from the surrounding `AbsintheCache.DocumentProvider` module
         @ttl Keyword.get(opts, :ttl, 120)
         @max_ttl_ffset Keyword.get(opts, :max_ttl_offset, 60)
-        @cache_key_fun Keyword.get(opts, :additional_cache_key_args_fun, fn _ -> :ok end)
+        @cache_key_fun Keyword.get(
+                         opts,
+                         :additional_cache_key_args_fun,
+                         &__MODULE__.additional_cache_key_args_fun_default/1
+                       )
+
+        def additional_cache_key_args_fun_default(_), do: :ok
 
         @spec run(Absinthe.Blueprint.t(), Keyword.t()) :: Absinthe.Phase.result_t()
         def run(bp_root, _) do

--- a/lib/document_provider.ex
+++ b/lib/document_provider.ex
@@ -31,11 +31,11 @@ defmodule AbsintheCache.DocumentProvider do
         pipeline
         |> Absinthe.Pipeline.insert_before(
           Absinthe.Phase.Document.Execution.Resolution,
-          CacheDocument
+          __MODULE__.CacheDocument
         )
         |> Absinthe.Pipeline.insert_after(
           Absinthe.Phase.Document.Result,
-          Idempotent
+          __MODULE__.Idempotent
         )
       end
 


### PR DESCRIPTION
The concept of this package is great, but I could not get it to work out-of-the-box using the configuration in Example II.

At first, my modules in my main codebase would not compile because `@cache_key_fun` tries to store an anonymous function, [which an attribute cannot do](https://elixirforum.com/t/cannot-compile-attribute/21052/3?u=drewble).
```elixir
@cache_key_fun Keyword.get(opts, :additional_cache_key_args_fun, fn _ -> :ok end)
```

Next, the `Absinthe.Phase` pipeline could not locate the `CacheDocument` module without including the full namespace as so.
```elixir
def pipeline(%Absinthe.Plug.Request.Query{pipeline: pipeline}) do
        pipeline
        |> Absinthe.Pipeline.insert_before(
          Absinthe.Phase.Document.Execution.Resolution,
          __MODULE__.CacheDocument
        )
        ....
end
```

Then, every request, even on queries I had designated for caching I was getting cache misses. I believe the `do_not_cache?` logic in `BeforeSend` is backwards, as it will never resolve to `false`.

Finally, the full alias of the `Idempotent` module used in the `{:jump}` seems to be leftover from the hardcoded version. I don't think the `Idempotent` module needs to be part of the macro, so I moved it out of the macro and nested it directly in `AbsintheCache.DocumentProvider`. This is working great for me now.

Hopefully these changes are not unique to my situation and will help make this module useful for others!